### PR TITLE
CL:PROBE-FILE signals an error when passed a directory on CLISP.

### DIFF
--- a/clhs.asd
+++ b/clhs.asd
@@ -18,4 +18,5 @@ Thin ASDF wrapper (excluding HyperSpec): Public Domain"
   :serial cl:t
   :components ((:module "HyperSpec-7-0")
 	       (:file "package")
-	       (:file "main")))
+	       (:file "main"))
+  :depends-on (:cl-fad))

--- a/main.lisp
+++ b/main.lisp
@@ -32,7 +32,7 @@
 (defun %copy-file (source destination
                    &key (if-source-does-not-exist :error)
                    (if-destination-exists :error))
-  (unless (and (eq if-destination-exists nil) (probe-file destination))
+  (unless (and (eq if-destination-exists nil) (cl-fad:directory-exists-p destination))
     (let (buffer)
       (with-open-file (in source
                           :direction :input
@@ -63,11 +63,11 @@
 
 (defun clhs-use-local-status (&key (quicklisp-directory *quicklisp-directory*))
   (let* ((bundled
-          (probe-file (%clhs-use-local *system-directory*)))
+          (cl-fad:file-exists-p (%clhs-use-local *system-directory*)))
          (expected-installed
           (%clhs-use-local quicklisp-directory))
          (installed
-          (probe-file expected-installed))
+          (cl-fad:file-exists-p expected-installed))
          (bundled-version (%clhs-use-local-version bundled))
          (installed-version (%clhs-use-local-version installed)))
     (values (cond ((not installed)
@@ -93,7 +93,7 @@
   (if ensure-directories-exist-p
       (ensure-directories-exist destination-directory :verbose verbose))
   (if (and (not ensure-directories-exist-p)
-           (not (probe-file destination-directory)))
+           (not (cl-fad:directory-exists-p destination-directory)))
       (let ((directory (directory-namestring destination-directory)))
         (if (pathname-match-p destination-directory *quicklisp-directory*)
             (format t "The following doesn't seem to be ~
@@ -193,7 +193,7 @@ and how to get Emacs to open CLHS pages in a different browser.
       (format t "~2&[ Quicklisp directory: \"~A\" (~A)~%  ~
                       If the above location is not correct, do:~%  ~A ]"
               directory
-              (if (probe-file directory) "exists" "DOES NOT exist")
+              (if (cl-fad:directory-exists-p directory) "exists" "DOES NOT exist")
               (%quicklisp-directory-setf-example)))
     (if (not indirectp)
         (apply #'%print :step-2 common)

--- a/package.lisp
+++ b/package.lisp
@@ -1,7 +1,8 @@
 (in-package #:cl-user)
 
 (defpackage #:clhs
-  (:use #:cl)
+  (:use #:cl
+	#:cl-fad)
   (:export #:*system-directory*
 	   #:*hyperspec-relative-directory*
            #:*quicklisp-directory*


### PR DESCRIPTION
Please refer to:

http://clisp.org/impnotes.html#probe-file

Their rationale for this is documented here:

http://clisp.org/impnotes.html#dir-is-not-file

This commit replaces calls to CL:PROBE-FILE with CL-FAD:FILE-EXISTS-P
and CL-FAD:DIRECTORY-EXISTS-P to make clhs work on CLISP.
