### PR TITLE
Fix quicklisp-clhs-ensure-symbolic-link

### DIFF
--- a/clhs-use-local.el
+++ b/clhs-use-local.el
@@ -35,6 +35,10 @@
           "HyperSpec"
           (if as-directory-p "/" "")))
 
+(defun quicklisp-clhs-symlink-resolved (&optional as-directory-p)
+  (concat (file-symlink-p (quicklisp-clhs-symlink-location))
+          (if as-directory-p "/" "")))
+
 (defun quicklisp-clhs-hyperspec-location (&optional through-symlink-p)
   (if through-symlink-p
       (quicklisp-clhs-symlink-location t)
@@ -50,12 +54,9 @@
        quicklisp-clhs-inhibit-symlink-relative-p))
 
 (defun quicklisp-clhs-ensure-symbolic-link (symlink-location path)
-  (if (and (eq system-type 'windows-nt) ;; windows seems not to recognize symlinks
-           (file-directory-p (quicklisp-clhs-symlink-location)))
-      t
-    (let ((current-path (file-symlink-p symlink-location)))
-      (when (or (not current-path) (not (string-equal current-path path)))
-        (make-symbolic-link path symlink-location t)))))
+  (let ((current-path (quicklisp-clhs-symlink-resolved t)))
+    (when (or (not current-path) (not (string-equal current-path path)))
+      (make-symbolic-link path symlink-location t))))
 
 (defun quicklisp-clhs-setup-symlink (&optional relativep)
   (let ((symlink-location (quicklisp-clhs-symlink-location))

--- a/clhs-use-local.el
+++ b/clhs-use-local.el
@@ -35,10 +35,6 @@
           "HyperSpec"
           (if as-directory-p "/" "")))
 
-(defun quicklisp-clhs-symlink-resolved (&optional as-directory-p)
-  (concat (file-symlink-p (quicklisp-clhs-symlink-location))
-          (if as-directory-p "/" "")))
-
 (defun quicklisp-clhs-hyperspec-location (&optional through-symlink-p)
   (if through-symlink-p
       (quicklisp-clhs-symlink-location t)
@@ -53,8 +49,11 @@
   (and (boundp 'quicklisp-clhs-inhibit-symlink-relative-p)
        quicklisp-clhs-inhibit-symlink-relative-p))
 
+(defun quicklisp-clhs-resolve-symlink-as-folder (link)
+  (concat (file-symlink-p link) "/"))
+
 (defun quicklisp-clhs-ensure-symbolic-link (symlink-location path)
-  (let ((current-path (quicklisp-clhs-symlink-resolved t)))
+  (let ((current-path (quicklisp-clhs-resolve-symlink-as-folder symlink-location)))
     (when (or (not current-path) (not (string-equal current-path path)))
       (make-symbolic-link path symlink-location t))))
 

--- a/clhs-use-local.el
+++ b/clhs-use-local.el
@@ -50,9 +50,12 @@
        quicklisp-clhs-inhibit-symlink-relative-p))
 
 (defun quicklisp-clhs-ensure-symbolic-link (symlink-location path)
-  (let ((current-path (file-symlink-p symlink-location)))
-    (when (or (not current-path) (not (string-equal current-path path)))
-      (make-symbolic-link path symlink-location t))))
+  (if (and (eq system-type 'windows-nt) ;; windows seems not to recognize symlinks
+           (file-directory-p (quicklisp-clhs-symlink-location)))
+      t
+    (let ((current-path (file-symlink-p symlink-location)))
+      (when (or (not current-path) (not (string-equal current-path path)))
+        (make-symbolic-link path symlink-location t)))))
 
 (defun quicklisp-clhs-setup-symlink (&optional relativep)
   (let ((symlink-location (quicklisp-clhs-symlink-location))


### PR DESCRIPTION
This removes the warning if what should be recognized as a symlink exists as a folder on Windows. (Issue #10)