### PR TITLE
fix quicklisp-clhs-ensure-symbolic-link

### DIFF
--- a/clhs-use-local.el
+++ b/clhs-use-local.el
@@ -49,8 +49,11 @@
   (and (boundp 'quicklisp-clhs-inhibit-symlink-relative-p)
        quicklisp-clhs-inhibit-symlink-relative-p))
 
+(defun quicklisp-clhs-resolve-symlink-as-folder (link)
+  (concat (file-symlink-p link) "/"))
+
 (defun quicklisp-clhs-ensure-symbolic-link (symlink-location path)
-  (let ((current-path (file-symlink-p symlink-location)))
+  (let ((current-path (quicklisp-clhs-resolve-symlink-as-folder symlink-location)))
     (when (or (not current-path) (not (string-equal current-path path)))
       (make-symbolic-link path symlink-location t))))
 

--- a/clhs-use-local.el
+++ b/clhs-use-local.el
@@ -49,11 +49,8 @@
   (and (boundp 'quicklisp-clhs-inhibit-symlink-relative-p)
        quicklisp-clhs-inhibit-symlink-relative-p))
 
-(defun quicklisp-clhs-resolve-symlink-as-folder (link)
-  (concat (file-symlink-p link) "/"))
-
 (defun quicklisp-clhs-ensure-symbolic-link (symlink-location path)
-  (let ((current-path (quicklisp-clhs-resolve-symlink-as-folder symlink-location)))
+  (let ((current-path (concat (file-symlink-p symlink-location) "/")))
     (when (or (not current-path) (not (string-equal current-path path)))
       (make-symbolic-link path symlink-location t))))
 


### PR DESCRIPTION
One of the paths being compared was missing a trailing slash.